### PR TITLE
Implement methodology ontology into offset entities

### DIFF
--- a/polygon-bridged-carbon/generated/schema.ts
+++ b/polygon-bridged-carbon/generated/schema.ts
@@ -27,6 +27,7 @@ export class CarbonOffset extends Entity {
     this.set("projectID", Value.fromString(""));
     this.set("standard", Value.fromString(""));
     this.set("methodology", Value.fromString(""));
+    this.set("methodologyCategory", Value.fromString(""));
     this.set("country", Value.fromString(""));
     this.set("region", Value.fromString(""));
     this.set("storageMethod", Value.fromString(""));
@@ -167,6 +168,15 @@ export class CarbonOffset extends Entity {
 
   set methodology(value: string) {
     this.set("methodology", Value.fromString(value));
+  }
+
+  get methodologyCategory(): string {
+    let value = this.get("methodologyCategory");
+    return value!.toString();
+  }
+
+  set methodologyCategory(value: string) {
+    this.set("methodologyCategory", Value.fromString(value));
   }
 
   get country(): string {
@@ -345,6 +355,62 @@ export class CarbonOffset extends Entity {
 
   set lastUpdate(value: BigInt) {
     this.set("lastUpdate", Value.fromBigInt(value));
+  }
+}
+
+export class UndefinedCategory extends Entity {
+  constructor(id: string) {
+    super();
+    this.set("id", Value.fromString(id));
+
+    this.set("tokenAddress", Value.fromBytes(Bytes.empty()));
+    this.set("methodology", Value.fromString(""));
+  }
+
+  save(): void {
+    let id = this.get("id");
+    assert(id != null, "Cannot save UndefinedCategory entity without an ID");
+    if (id) {
+      assert(
+        id.kind == ValueKind.STRING,
+        "Cannot save UndefinedCategory entity with non-string ID. " +
+          'Considering using .toHex() to convert the "id" to a string.'
+      );
+      store.set("UndefinedCategory", id.toString(), this);
+    }
+  }
+
+  static load(id: string): UndefinedCategory | null {
+    return changetype<UndefinedCategory | null>(
+      store.get("UndefinedCategory", id)
+    );
+  }
+
+  get id(): string {
+    let value = this.get("id");
+    return value!.toString();
+  }
+
+  set id(value: string) {
+    this.set("id", Value.fromString(value));
+  }
+
+  get tokenAddress(): Bytes {
+    let value = this.get("tokenAddress");
+    return value!.toBytes();
+  }
+
+  set tokenAddress(value: Bytes) {
+    this.set("tokenAddress", Value.fromBytes(value));
+  }
+
+  get methodology(): string {
+    let value = this.get("methodology");
+    return value!.toString();
+  }
+
+  set methodology(value: string) {
+    this.set("methodology", Value.fromString(value));
   }
 }
 

--- a/polygon-bridged-carbon/generated/schema.ts
+++ b/polygon-bridged-carbon/generated/schema.ts
@@ -358,62 +358,6 @@ export class CarbonOffset extends Entity {
   }
 }
 
-export class UndefinedCategory extends Entity {
-  constructor(id: string) {
-    super();
-    this.set("id", Value.fromString(id));
-
-    this.set("tokenAddress", Value.fromBytes(Bytes.empty()));
-    this.set("methodology", Value.fromString(""));
-  }
-
-  save(): void {
-    let id = this.get("id");
-    assert(id != null, "Cannot save UndefinedCategory entity without an ID");
-    if (id) {
-      assert(
-        id.kind == ValueKind.STRING,
-        "Cannot save UndefinedCategory entity with non-string ID. " +
-          'Considering using .toHex() to convert the "id" to a string.'
-      );
-      store.set("UndefinedCategory", id.toString(), this);
-    }
-  }
-
-  static load(id: string): UndefinedCategory | null {
-    return changetype<UndefinedCategory | null>(
-      store.get("UndefinedCategory", id)
-    );
-  }
-
-  get id(): string {
-    let value = this.get("id");
-    return value!.toString();
-  }
-
-  set id(value: string) {
-    this.set("id", Value.fromString(value));
-  }
-
-  get tokenAddress(): Bytes {
-    let value = this.get("tokenAddress");
-    return value!.toBytes();
-  }
-
-  set tokenAddress(value: Bytes) {
-    this.set("tokenAddress", Value.fromBytes(value));
-  }
-
-  get methodology(): string {
-    let value = this.get("methodology");
-    return value!.toString();
-  }
-
-  set methodology(value: string) {
-    this.set("methodology", Value.fromString(value));
-  }
-}
-
 export class Bridge extends Entity {
   constructor(id: string) {
     super();

--- a/polygon-bridged-carbon/schema.graphql
+++ b/polygon-bridged-carbon/schema.graphql
@@ -11,6 +11,7 @@ type CarbonOffset @entity {
   projectID: String!
   standard: String!
   methodology: String!
+  methodologyCategory: String!
   country: String!
   region: String!
   storageMethod: String!

--- a/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
+++ b/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
@@ -2,6 +2,7 @@ import { Address, BigDecimal, BigInt } from "@graphprotocol/graph-ts"
 import { CarbonOffset, Transaction } from '../../generated/schema'
 import { ToucanCarbonOffsets } from "../../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets"
 import { C3ProjectToken } from "../../generated/templates/C3ProjectToken/C3ProjectToken"
+import { MethodologyCategories } from "./MethodologyCategories"
 
 
 export function loadOrCreateCarbonOffset(transaction: Transaction, token: Address, bridge: String, registry: String): CarbonOffset {
@@ -70,6 +71,7 @@ export function createToucanCarbonOffset(transaction: Transaction, token: Addres
     carbonOffset.projectID = attributes.value0.projectId
     carbonOffset.standard = attributes.value0.standard
     carbonOffset.methodology = attributes.value0.methodology
+    carbonOffset.methodologyCategory = MethodologyCategories.getMethodologyCategory(carbonOffset.methodology)
     carbonOffset.region = attributes.value0.region
     carbonOffset.storageMethod = attributes.value0.storageMethod
     carbonOffset.method = attributes.value0.method
@@ -123,6 +125,7 @@ export function createC3ProjectToken(transaction: Transaction, token: Address, b
     carbonOffset.projectID = attributes.project_id
     carbonOffset.standard = attributes.registry
     carbonOffset.methodology = attributes.methodology
+    carbonOffset.methodologyCategory = MethodologyCategories.getMethodologyCategory(carbonOffset.methodology)
     carbonOffset.country = attributes.country
     carbonOffset.region = attributes.region
     carbonOffset.category = attributes.project_type

--- a/polygon-bridged-carbon/src/utils/MethodologyCategories.ts
+++ b/polygon-bridged-carbon/src/utils/MethodologyCategories.ts
@@ -1,0 +1,217 @@
+export class MethodologyCategories {
+  static map: Map<string, string> | null = null
+
+  /**
+   * Gets a category based on methodology of an offset.
+   * Since there are occurences of multiple methodologies separated by comma, if methodology is not found initially within a map, methodology is split into array.
+   * That array will be iterated and checked if category for each methodology in array exists.
+   * @param methodology Methodology of an offset
+   * @returns 
+   */
+  public static getMethodologyCategory(methodology: string): string {
+    const map = this.getMap()
+    if (map == null) {
+      throw new Error("Map cannot be null")
+    }
+    if (map.has(methodology)) {
+      return map.get(methodology)
+    } 
+
+    const methodologyArray = methodology.split(",")
+    const categories = this.getCategoriesFromMultipleMethodologies(methodologyArray, map)
+    return categories
+  }
+
+  private static getCategoriesFromMultipleMethodologies(methodologyArray: string[], map: Map<string, string>): string {
+    let categories: string = ""
+    for (let i = 0; i < methodologyArray.length; i++) {
+      const currentMethodology = methodologyArray[i].trim()
+      if(!map.has(currentMethodology)) {
+        continue;
+      }
+      if (categories.length > 0) {
+        categories+=", "
+      }
+        categories+=map.get(currentMethodology)
+    }
+    return categories
+  }
+
+  private static getMap(): Map<string, string> | null {
+    if (this.map == null) {
+      this.map = this.loadMap();
+    }
+    return this.map;
+  }
+
+  private static loadMap(): Map<string, string> {
+    const map = new Map<string, string>();
+
+    //Renewable Energy
+    map.set("AM0103", "Renewable Energy");
+    map.set("ACM0002", "Renewable Energy");
+    map.set("AMS-I.D.", "Renewable Energy");
+    map.set("AMS-I.C.", "Renewable Energy");
+    map.set("ACM0018", "Renewable Energy");
+
+    //Energy Efficiency
+    map.set("AM0038", "Energy Efficiency");
+    map.set("AM0043", "Energy Efficiency");
+    map.set("AM0044", "Energy Efficiency");
+    map.set("AM0046", "Energy Efficiency");
+    map.set("AM0055", "Energy Efficiency");
+    map.set("AM0055", "Energy Efficiency");
+    map.set("AM0056", "Energy Efficiency");
+    map.set("AM0061", "Energy Efficiency");
+    map.set("AM0062", "Energy Efficiency");
+    map.set("AM0067", "Energy Efficiency");
+    map.set("AM0091", "Energy Efficiency");
+    map.set("AM0105", "Energy Efficiency");
+    map.set("AM0106", "Energy Efficiency");
+    map.set("AM0113", "Energy Efficiency");
+    map.set("AM0114", "Energy Efficiency");
+    map.set("AM0115", "Energy Efficiency");
+    map.set("AM0116", "Energy Efficiency");
+    map.set("AM0117", "Energy Efficiency");
+    map.set("AM0118", "Energy Efficiency");
+    map.set("AM0119", "Energy Efficiency");
+    map.set("AM0120", "Energy Efficiency");
+    map.set("AM0121", "Energy Efficiency");
+    map.set("VM0008", "Energy Efficiency");
+    map.set("VM0018", "Energy Efficiency");
+    map.set("VM0019", "Energy Efficiency");
+    map.set("VM0020", "Energy Efficiency");
+    map.set("VM0025", "Energy Efficiency");
+    map.set("VMR0005", "Energy Efficiency");
+    map.set("VMR0006", "Energy Efficiency");
+    map.set("VM0001", "Energy Efficiency");
+    map.set("VM0002", "Energy Efficiency");
+    map.set("VM0008", "Energy Efficiency");
+    map.set("VM0019", "Energy Efficiency");
+    map.set("VM0020", "Energy Efficiency");
+    map.set("VM0018", "Energy Efficiency");
+    map.set("ACM0012", "Energy Efficiency");
+    map.set("AMS-III.Z", "Energy Efficiency");
+    map.set("GS TPDDTEC v 1.", "Energy Efficiency");
+    map.set("AMS-II.G.", "Energy Efficiency");
+
+    //Agriculture
+    map.set("VM0041", "Agriculture");
+    map.set("VM0042", "Agriculture");
+    map.set("VM0017", "Agriculture");
+    map.set("VMR0003", "Agriculture");
+    map.set("AMS-III.AU.", "Agriculture");
+    map.set("AMS-III.BE", "Agriculture");
+    map.set("AMS-III.BF", "Agriculture");
+    map.set("VM0017", "Agriculture");
+    map.set("AMS-III.D.", "Agriculture");
+
+    //Forestry
+    map.set("VM0004", "Forestry");
+    map.set("VM0007", "Forestry");
+    map.set("VM0024", "Forestry");
+    map.set("VM0027", "Forestry");
+    map.set("VM0033", "Forestry");
+    map.set("VM0036", "Forestry");
+    map.set("VM0003", "Forestry");
+    map.set("VM0004", "Forestry");
+    map.set("VM0005", "Forestry");
+    map.set("VM0006", "Forestry");
+    map.set("VM0007", "Forestry");
+    map.set("VM0009", "Forestry");
+    map.set("VM0010", "Forestry");
+    map.set("VM0011", "Forestry");
+    map.set("VM0012", "Forestry");
+    map.set("VM0015", "Forestry");
+    map.set("VM0029", "Forestry");
+    map.set("VM0034", "Forestry");
+    map.set("VM0035", "Forestry");
+    map.set("VM0037", "Forestry");
+    map.set("AR-ACM0003", "Forestry");
+    map.set("AR-AM0014", "Forestry");
+    map.set("AR-AMS0003", "Forestry");
+    map.set("AR-AMS0007", "Forestry");
+    map.set("AR-ACM0001", "Forestry");
+    map.set("AM0014", "Forestry");
+
+    //Other nature based
+    map.set("VM0021", "Other Nature-Based");
+    map.set("VM0026", "Other Nature-Based");
+    map.set("VM0032", "Other Nature-Based");
+    map.set("AM0010", "Other Nature Based");
+        
+    //Industrial processing
+    map.set("AM0048", "Industrial Processing");
+    map.set("AM0050", "Industrial Processing");
+    map.set("AM0059", "Industrial Processing");
+    map.set("AM0092", "Industrial Processing");
+    map.set("AM0095", "Industrial Processing");
+    map.set("AM0096", "Industrial Processing");
+    map.set("AMS-III.M.", "Industrial Processing ");
+    map.set("AM0025", "Industrial Processing");
+
+    //Other
+    map.set("AM0052", "Other");
+    map.set("AM0053", "Other");
+    map.set("AM0057", "Other");
+    map.set("AM0058", "Other");
+    map.set("AM0064", "Other");
+    map.set("AM0065", "Other");
+    map.set("AM0066", "Other");
+    map.set("AM0069", "Other");
+    map.set("AM0070", "Other");
+    map.set("AM0070", "Other");
+    map.set("AM0072", "Other");
+    map.set("AM0073", "Other");
+    map.set("AM0074", "Other");
+    map.set("AM0075", "Other");
+    map.set("AM0076", "Other");
+    map.set("AM0077", "Other");
+    map.set("AM0078", "Other");
+    map.set("AM0079", "Other");
+    map.set("AM0080", "Other");
+    map.set("AM0081", "Other");
+    map.set("AM0082", "Other");
+    map.set("AM0083", "Other");
+    map.set("AM0084", "Other");
+    map.set("AM0086", "Other");
+    map.set("AM0088", "Other");
+    map.set("AM0089", "Other");
+    map.set("AM0090", "Other");
+    map.set("AM0093", "Other");
+    map.set("AM0094", "Other");
+    map.set("AM0097", "Other");
+    map.set("AM0098", "Other");
+    map.set("AM0100", "Other");
+    map.set("AM0104", "Other");
+    map.set("AM0107", "Other");
+    map.set("AM0108", "Other");
+    map.set("AM0109", "Other");
+    map.set("AM0110", "Other");
+    map.set("AM0112", "Other");
+    map.set("AM0122", "Other");
+    map.set("VM0013", "Other");
+    map.set("VM0040", "Other");
+    map.set("VMR0004", "Other");
+    map.set("VM0014", "Other");
+    map.set("VM0016", "Other");
+    map.set("VM0023", "Other");
+    map.set("VM0030", "Other");
+    map.set("VM0031", "Other");
+    map.set("VM0040", "Other");
+    map.set("VM0043", "Other");
+    map.set("VM0039", "Other");
+    map.set("VMR0004", "Other");
+    map.set("VMR0001", "Other");
+    map.set("VMR0002", "Other");
+    map.set("ACM0001", "Other");
+    map.set("ACM0006", "Other");
+    map.set("AM0029", "Other");
+    map.set("AM0001", "Other");
+    map.set("AMS-III.G.", "Other");
+    map.set("AM0009", "Other");
+    map.set("AMS-III.H.", "Other");
+
+    return map
+  }
+}


### PR DESCRIPTION
- Since there is already a `category` field within `CarbonOffset` entities - I've added `methodologyCategory` field.
- Added `MethodologyCategories.ts` that returns a `methodologyCategory` for a particular methodology of an offset
- `methodologyCategory` is assigned on offset creation within `CarbonOffsets.ts`
- In case of MCO2 offset(s) - if `methodology = ""` , then also `methodologyCategory = ""`

Subgraph can be found [here](https://api.thegraph.com/subgraphs/id/QmfGzwHdzHSHJFfFCMfnQvFZiMXUVsWQY6vo5nmBftquyR/graphql?query=query+MyQuery+%7B%0A++carbonOffsets+%7B%0A++++id%0A++++methodology%0A++++methodologyCategory%0A++%7D%0A%7D).

Resolves #18
