### PR TITLE
Fulltext search for `CarbonOffsets`

### DIFF
--- a/lib/utils/Dates.ts
+++ b/lib/utils/Dates.ts
@@ -1,6 +1,6 @@
 import { BigInt, log } from "@graphprotocol/graph-ts";
 
-export function yearFromTimestamp(timestamp: BigInt): string {
+export function stdYearFromTimestamp(timestamp: BigInt): string {
     let year_ts = timestamp.toI32() - (timestamp.toI32() % 31556926)
     return ((year_ts / 31556926) + 1970).toString()
 }

--- a/lib/utils/Dates.ts
+++ b/lib/utils/Dates.ts
@@ -1,5 +1,10 @@
 import { BigInt, log } from "@graphprotocol/graph-ts";
 
+export function yearFromTimestamp(timestamp: BigInt): string {
+    let year_ts = timestamp.toI32() - (timestamp.toI32() % 31556926)
+    return ((year_ts / 31556926) + 1970).toString()
+}
+
 export function dayFromTimestamp(timestamp: BigInt): string {
     let day_ts = timestamp.toI32() - (timestamp.toI32() % 86400)
     return day_ts.toString()

--- a/polygon-bridged-carbon/generated/schema.ts
+++ b/polygon-bridged-carbon/generated/schema.ts
@@ -24,6 +24,7 @@ export class CarbonOffset extends Entity {
     this.set("totalRetired", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("currentSupply", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("vintage", Value.fromString(""));
+    this.set("vintageYear", Value.fromString(""));
     this.set("projectID", Value.fromString(""));
     this.set("standard", Value.fromString(""));
     this.set("methodology", Value.fromString(""));
@@ -141,6 +142,15 @@ export class CarbonOffset extends Entity {
 
   set vintage(value: string) {
     this.set("vintage", Value.fromString(value));
+  }
+
+  get vintageYear(): string {
+    let value = this.get("vintageYear");
+    return value!.toString();
+  }
+
+  set vintageYear(value: string) {
+    this.set("vintageYear", Value.fromString(value));
   }
 
   get projectID(): string {

--- a/polygon-bridged-carbon/schema.graphql
+++ b/polygon-bridged-carbon/schema.graphql
@@ -1,4 +1,22 @@
-type CarbonOffset @entity {
+type _Schema_
+  @fulltext(
+    name: "carbonOffsetSearch"
+    language: en
+    algorithm: rank
+    include: [
+      { 
+         entity: "CarbonOffset", 
+         fields: [
+            { name: "methodologyCategory" },
+            { name: "region" },
+            { name: "country" },
+            { name: "vintageYear" }
+         ] 
+      }
+   ]
+  )
+  
+  type CarbonOffset @entity {
   id: ID!
   name: String!
   tokenAddress: String!
@@ -8,6 +26,7 @@ type CarbonOffset @entity {
   totalRetired: BigDecimal!
   currentSupply: BigDecimal!
   vintage: String!
+  vintageYear: String!
   projectID: String!
   standard: String!
   methodology: String!

--- a/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
+++ b/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
@@ -3,7 +3,7 @@ import { CarbonOffset, Transaction } from '../../generated/schema'
 import { ToucanCarbonOffsets } from "../../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets"
 import { C3ProjectToken } from "../../generated/templates/C3ProjectToken/C3ProjectToken"
 import { MethodologyCategories } from "./MethodologyCategories"
-import { yearFromTimestamp } from "../../../lib/utils/Dates"
+import { stdYearFromTimestamp } from "../../../lib/utils/Dates"
 
 export function loadOrCreateCarbonOffset(transaction: Transaction, token: Address, bridge: String, registry: String): CarbonOffset {
 
@@ -69,7 +69,7 @@ export function createToucanCarbonOffset(transaction: Transaction, token: Addres
     carbonOffset.region = ''
 
     carbonOffset.vintage = attributes.value1.startTime.toString()
-    carbonOffset.vintageYear = yearFromTimestamp(attributes.value1.startTime)
+    carbonOffset.vintageYear = stdYearFromTimestamp(attributes.value1.startTime)
     carbonOffset.projectID = attributes.value0.projectId
     carbonOffset.standard = attributes.value0.standard
     carbonOffset.methodology = attributes.value0.methodology
@@ -122,7 +122,7 @@ export function createC3ProjectToken(transaction: Transaction, token: Address, b
             0
         ) / 1000
     ).toString()
-    carbonOffset.vintageYear = yearFromTimestamp(carbonOffsetERC20.getVintage())
+    carbonOffset.vintageYear = stdYearFromTimestamp(carbonOffsetERC20.getVintage())
 
     carbonOffset.name = attributes.name
     carbonOffset.projectID = attributes.project_id

--- a/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
+++ b/polygon-bridged-carbon/src/utils/CarbonOffsets.ts
@@ -3,7 +3,7 @@ import { CarbonOffset, Transaction } from '../../generated/schema'
 import { ToucanCarbonOffsets } from "../../generated/templates/ToucanCarbonOffsets/ToucanCarbonOffsets"
 import { C3ProjectToken } from "../../generated/templates/C3ProjectToken/C3ProjectToken"
 import { MethodologyCategories } from "./MethodologyCategories"
-
+import { yearFromTimestamp } from "../../../lib/utils/Dates"
 
 export function loadOrCreateCarbonOffset(transaction: Transaction, token: Address, bridge: String, registry: String): CarbonOffset {
 
@@ -27,6 +27,7 @@ export function loadOrCreateCarbonOffset(transaction: Transaction, token: Addres
             carbonOffset.totalRetired = BigDecimal.fromString('0')
             carbonOffset.currentSupply = BigDecimal.fromString('0')
             carbonOffset.vintage = ''
+            carbonOffset.vintageYear = ''
             carbonOffset.projectID = ''
             carbonOffset.standard = ''
             carbonOffset.methodology = ''
@@ -68,6 +69,7 @@ export function createToucanCarbonOffset(transaction: Transaction, token: Addres
     carbonOffset.region = ''
 
     carbonOffset.vintage = attributes.value1.startTime.toString()
+    carbonOffset.vintageYear = yearFromTimestamp(attributes.value1.startTime)
     carbonOffset.projectID = attributes.value0.projectId
     carbonOffset.standard = attributes.value0.standard
     carbonOffset.methodology = attributes.value0.methodology
@@ -120,6 +122,7 @@ export function createC3ProjectToken(transaction: Transaction, token: Address, b
             0
         ) / 1000
     ).toString()
+    carbonOffset.vintageYear = yearFromTimestamp(carbonOffsetERC20.getVintage())
 
     carbonOffset.name = attributes.name
     carbonOffset.projectID = attributes.project_id

--- a/polygon-bridged-carbon/subgraph.yaml
+++ b/polygon-bridged-carbon/subgraph.yaml
@@ -1,8 +1,10 @@
-specVersion: 0.0.2
+specVersion: 0.0.4
 description: Polygon Bridged Carbon
 repository: https://github.com/KlimaDAO/carbon-subgraph
 schema:
   file: ./schema.graphql
+features:
+  - fullTextSearch
 dataSources:
   - kind: ethereum/contract
     name: ToucanFactory


### PR DESCRIPTION
Add fulltext search functionality for `CarbonOffsets` entity. 
Add in normalized year value field to use within the search.

Testing deployment can be found here: 
https://api.thegraph.com/subgraphs/name/cujowolf/polygon-bridged-carbon-dev

Example query for Forestry credits from 2012:
```
query TestQuery {
  carbonOffsetSearch(text: "Forestry | 2012") {
    tokenAddress
    balanceBCT
    balanceNCT
  }
}
```