### PR TITLE
feature/redemption-metrics: Added redemption information within Polygon CarbonMetrics

### DIFF
--- a/polygon-bridged-carbon/generated/schema.ts
+++ b/polygon-bridged-carbon/generated/schema.ts
@@ -1229,6 +1229,10 @@ export class CarbonMetric extends Entity {
     this.set("mco2Supply", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("uboSupply", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("nboSupply", Value.fromBigDecimal(BigDecimal.zero()));
+    this.set("bctRedeemed", Value.fromBigDecimal(BigDecimal.zero()));
+    this.set("nctRedeemed", Value.fromBigDecimal(BigDecimal.zero()));
+    this.set("uboRedeemed", Value.fromBigDecimal(BigDecimal.zero()));
+    this.set("nboRedeemed", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("totalCarbonSupply", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("bctCrosschainSupply", Value.fromBigDecimal(BigDecimal.zero()));
     this.set("nctCrosschainSupply", Value.fromBigDecimal(BigDecimal.zero()));
@@ -1323,6 +1327,42 @@ export class CarbonMetric extends Entity {
 
   set nboSupply(value: BigDecimal) {
     this.set("nboSupply", Value.fromBigDecimal(value));
+  }
+
+  get bctRedeemed(): BigDecimal {
+    let value = this.get("bctRedeemed");
+    return value!.toBigDecimal();
+  }
+
+  set bctRedeemed(value: BigDecimal) {
+    this.set("bctRedeemed", Value.fromBigDecimal(value));
+  }
+
+  get nctRedeemed(): BigDecimal {
+    let value = this.get("nctRedeemed");
+    return value!.toBigDecimal();
+  }
+
+  set nctRedeemed(value: BigDecimal) {
+    this.set("nctRedeemed", Value.fromBigDecimal(value));
+  }
+
+  get uboRedeemed(): BigDecimal {
+    let value = this.get("uboRedeemed");
+    return value!.toBigDecimal();
+  }
+
+  set uboRedeemed(value: BigDecimal) {
+    this.set("uboRedeemed", Value.fromBigDecimal(value));
+  }
+
+  get nboRedeemed(): BigDecimal {
+    let value = this.get("nboRedeemed");
+    return value!.toBigDecimal();
+  }
+
+  set nboRedeemed(value: BigDecimal) {
+    this.set("nboRedeemed", Value.fromBigDecimal(value));
   }
 
   get totalCarbonSupply(): BigDecimal {

--- a/polygon-bridged-carbon/schema.graphql
+++ b/polygon-bridged-carbon/schema.graphql
@@ -157,6 +157,10 @@ type CarbonMetric @entity {
   mco2Supply: BigDecimal!
   uboSupply: BigDecimal!
   nboSupply: BigDecimal!
+  bctRedeemed: BigDecimal!
+  nctRedeemed: BigDecimal!
+  uboRedeemed: BigDecimal!
+  nboRedeemed: BigDecimal!
   totalCarbonSupply: BigDecimal!
   bctCrosschainSupply: BigDecimal!
   nctCrosschainSupply: BigDecimal!

--- a/polygon-bridged-carbon/src/BaseCarbonTonne.ts
+++ b/polygon-bridged-carbon/src/BaseCarbonTonne.ts
@@ -42,4 +42,5 @@ export function handleRedeem(event: Redeemed): void {
     redeem.save()
 
     CarbonMetricUtils.updatePoolTokenSupply(new BCT(event.address), event.block.timestamp)
+    CarbonMetricUtils.updatePoolTokenRedemptions(new BCT(event.address), event.block.timestamp, event.params.amount)
 }

--- a/polygon-bridged-carbon/src/NBO.ts
+++ b/polygon-bridged-carbon/src/NBO.ts
@@ -40,4 +40,5 @@ export function handleRedeem(event: Redeemed): void {
     redeem.save()
 
     CarbonMetricUtils.updatePoolTokenSupply(new NBO(event.address), event.block.timestamp)
+    CarbonMetricUtils.updatePoolTokenRedemptions(new NBO(event.address), event.block.timestamp, event.params.amount)
 }

--- a/polygon-bridged-carbon/src/NCT.ts
+++ b/polygon-bridged-carbon/src/NCT.ts
@@ -40,4 +40,5 @@ export function handleRedeem(event: Redeemed): void {
     redeem.save()
 
     CarbonMetricUtils.updatePoolTokenSupply(new NCT(event.address), event.block.timestamp)
+    CarbonMetricUtils.updatePoolTokenRedemptions(new NCT(event.address), event.block.timestamp, event.params.amount)
 }

--- a/polygon-bridged-carbon/src/UBO.ts
+++ b/polygon-bridged-carbon/src/UBO.ts
@@ -40,4 +40,5 @@ export function handleRedeem(event: Redeemed): void {
     redeem.save()
 
     CarbonMetricUtils.updatePoolTokenSupply(new UBO(event.address), event.block.timestamp)
+    CarbonMetricUtils.updatePoolTokenRedemptions(new UBO(event.address), event.block.timestamp, event.params.amount)
 }

--- a/polygon-bridged-carbon/src/utils/CarbonMetrics.ts
+++ b/polygon-bridged-carbon/src/utils/CarbonMetrics.ts
@@ -32,6 +32,13 @@ export class CarbonMetricUtils {
     carbonMetrics.save()
   }
 
+  static updatePoolTokenRedemptions(poolToken: IPoolToken, timestamp: BigInt, amount: BigInt): void {
+    let carbonMetrics = this.loadCarbonMetrics(timestamp)
+    carbonMetrics = poolToken.returnUpdatedRedemptionMetrics(carbonMetrics, amount)
+
+    carbonMetrics.save()
+  }
+
   static updateCarbonTokenRetirements(carbonToken: ICarbonToken, timestamp: BigInt, amount: BigInt): void {
     let carbonMetrics = this.loadCarbonMetrics(timestamp)
     carbonMetrics = carbonToken.returnUpdatedRetirementMetrics(carbonMetrics, amount)

--- a/polygon-bridged-carbon/src/utils/pool_token/IPoolToken.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/IPoolToken.ts
@@ -4,6 +4,7 @@ import { CarbonMetric } from "../../../generated/schema";
 export interface IPoolToken {
   getDecimals(): number
   returnUpdatedSupplyMetrics(carbonMetrics: CarbonMetric): CarbonMetric
+  returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric
   returnUpdatedCrosschainSupplyMetrics(carbonMetrics: CarbonMetric, amountRaw: BigInt): CarbonMetric
   returnUpdatedKlimaRetirementMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric
 }

--- a/polygon-bridged-carbon/src/utils/pool_token/impl/BCT.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/impl/BCT.ts
@@ -51,4 +51,13 @@ export class BCT implements IPoolToken {
 
         return carbonMetrics
     }
+
+    returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+        const oldRedeemed = carbonMetrics.bctRedeemed
+        const newReeemed = carbonMetrics.bctRedeemed.plus(toDecimal(amount, this.getDecimals()))
+
+        carbonMetrics.bctRedeemed = newReeemed
+
+        return carbonMetrics
+    }
 }

--- a/polygon-bridged-carbon/src/utils/pool_token/impl/MCO2.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/impl/MCO2.ts
@@ -43,4 +43,8 @@ export class MCO2 implements IPoolToken {
 
         return carbonMetrics
     }
+
+    returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+        throw new Error("MCO2 is not redeemable");
+    }
 }

--- a/polygon-bridged-carbon/src/utils/pool_token/impl/NBO.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/impl/NBO.ts
@@ -44,4 +44,13 @@ export class NBO implements IPoolToken {
         return carbonMetrics
     }
 
+    returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+        const oldRedeemed = carbonMetrics.nboRedeemed
+        const newReeemed = carbonMetrics.nboRedeemed.plus(toDecimal(amount, this.getDecimals()))
+
+        carbonMetrics.nboRedeemed = newReeemed
+
+        return carbonMetrics
+    }
+
 }

--- a/polygon-bridged-carbon/src/utils/pool_token/impl/NCT.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/impl/NCT.ts
@@ -51,4 +51,12 @@ export class NCT implements IPoolToken {
         return carbonMetrics
     }
 
+    returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+        const oldRedeemed = carbonMetrics.nctRedeemed
+        const newReeemed = carbonMetrics.nctRedeemed.plus(toDecimal(amount, this.getDecimals()))
+
+        carbonMetrics.nctRedeemed = newReeemed
+
+        return carbonMetrics
+    }
 }

--- a/polygon-bridged-carbon/src/utils/pool_token/impl/UBO.ts
+++ b/polygon-bridged-carbon/src/utils/pool_token/impl/UBO.ts
@@ -44,4 +44,12 @@ export class UBO implements IPoolToken {
         return carbonMetrics
     }
 
+    returnUpdatedRedemptionMetrics(carbonMetrics: CarbonMetric, amount: BigInt): CarbonMetric {
+        const oldRedeemed = carbonMetrics.uboRedeemed
+        const newReeemed = carbonMetrics.uboRedeemed.plus(toDecimal(amount, this.getDecimals()))
+
+        carbonMetrics.uboRedeemed = newReeemed
+
+        return carbonMetrics
+    }
 }


### PR DESCRIPTION
`Carbonmetrics` entity within Polygon now include:
- bctRedeemed
- nctRedeemed
- uboRedeemed
- nboRedeemed information

[Test subgraph url](https://api.thegraph.com/subgraphs/id/QmT5pUeXwWuo7mmYpSiGbC8AznD5M2PDVLTxMB7mnENrCp/graphql?query=query+MyQuery+%7B%0A++carbonMetrics%28orderDirection%3A+desc%2C+orderBy%3A+timestamp%29+%7B%0A++++bctRedeemed%0A++++nctRedeemed%0A++++uboRedeemed%0A++++nboRedeemed%0A++%7D%0A%7D)
