### PR TITLE
Fix incorrect vintage year returned by modulo

### DIFF
--- a/lib/utils/Dates.ts
+++ b/lib/utils/Dates.ts
@@ -1,8 +1,8 @@
-import { BigInt, log } from "@graphprotocol/graph-ts";
+import { BigInt, log } from '@graphprotocol/graph-ts'
 
 export function stdYearFromTimestamp(timestamp: BigInt): string {
-    let year_ts = timestamp.toI32() - (timestamp.toI32() % 31556926)
-    return ((year_ts / 31556926) + 1970).toString()
+    let date = new Date(<i64>timestamp.toI32() * 1000)
+    return date.getUTCFullYear().toString()
 }
 
 export function dayFromTimestamp(timestamp: BigInt): string {


### PR DESCRIPTION
The current modulo operation fails for timestamps including a leap year. This updates the `stdYearFromTimestamp` function to properly create a date and return the full UTC year as a string.

Updated deployment deployed here: https://api.thegraph.com/subgraphs/id/QmUzZxrdKEXv3q8iQvyrQNtd6HCbEc2UGKLCbJy8ZS4C94